### PR TITLE
allow cwd and executable in mount, download from registry, mimic docker images output

### DIFF
--- a/tests/func_tests.py
+++ b/tests/func_tests.py
@@ -181,15 +181,15 @@ class MainTestCase(unittest.TestCase):
                 .return_value = False
             main = udocker.Main()
             main.execute()
-            msg_out = ("busybox:latest"
-                       "                                               .")
+            msg_out = ("busybox                        latest"
+                       "                         .")
             find_str(self, msg_out, mock_msg.out.call_args)
             # Protected
             mock_localrepo.return_value.isprotected_imagerepo\
                 .return_value = True
             main.execute()
-            msg_out = ("busybox:latest"
-                       "                                               P")
+            msg_out = ("busybox                        latest"
+                       "                         P")
             find_str(self, msg_out, mock_msg.out.call_args)
         t_argv = ['./udocker.py', "images", "-l"]
         with mock.patch.object(sys, 'argv', t_argv):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py27
 
 [testenv]
 deps =
+    simplejson
+    pycurl
     mock
     discover
     unittest2

--- a/udocker.py
+++ b/udocker.py
@@ -611,6 +611,7 @@ class Container(object):
 
     def _set_cpu_affinity(self):
         """set the cpu affinity string for container run command"""
+        cpu_affinity_exec = None  # avoids unbounded local error
         # find set affinity executable
         for exec_cmd in self._cpu_affinity_exec_tools:
             exec_name = FileUtil(exec_cmd.split(" ", 1)[0]).find_exec()

--- a/udocker.py
+++ b/udocker.py
@@ -698,10 +698,11 @@ class Container(object):
         if os.path.isdir(container_root + "/" + cwd):
             return True
         for volume in self.opt["vol"]:
-            if not ":" in volume:
+            if ":" in volume:
+                host_path, container_path = volume.split(":")
+            else:
                 host_path = volume
                 container_path = volume
-            host_path, container_path = volume.split(":")
             if cwd.startswith(container_path):
                 relative_path = cwd.split(container_path)[1].lstrip('/')
                 if os.path.isdir(os.path.join(host_path, relative_path)):
@@ -3186,11 +3187,11 @@ class Udocker(object):
         if cmdp.missing_options():               # syntax error
             return False
         images_list = self.localrepo.get_imagerepos()
-        msg.out("REPOSITORY")
+        msg.out("%-30.30s %-30.30s %s" % ("REPOSITORY", "TAG", "PROTECTED"))
         for (imagerepo, tag) in images_list:
             prot = (".", "P")[
                 self.localrepo.isprotected_imagerepo(imagerepo, tag)]
-            msg.out("%-60.60s %c" % (imagerepo + ":" + tag, prot))
+            msg.out("%-30.30s %-30.30s %c" % (imagerepo, tag, prot))
             if verbose:
                 imagerepo_dir = self.localrepo.cd_imagerepo(imagerepo, tag)
                 msg.out("  %s" % (imagerepo_dir))

--- a/udocker.py
+++ b/udocker.py
@@ -160,7 +160,7 @@ class Config(object):
         self.http_insecure = False
 
         # docker hub
-        self.dockerio_index_url = "https://registry-1.docker.io/v2"
+        self.dockerio_index_url = "https://index.docker.io/"
         self.dockerio_registry_url = "https://registry-1.docker.io"
 
         # -------------------------------------------------------------
@@ -2312,7 +2312,7 @@ class DockerIoAPI(object):
 
     def get_repo_info(self, imagerepo):
         """Get repo info from Docker Hub"""
-        url = self.index_url + "/repositories/" + imagerepo + "/"
+        url = self.index_url + "/v2/repositories/" + imagerepo + "/"
         msg.out("repo url:", url, l=2)
         (hdr, buf) = self._get_url(url)
         try:
@@ -2324,7 +2324,7 @@ class DockerIoAPI(object):
         """Get list of images in a repo from Docker Hub"""
         if not '/' in imagerepo:
             imagerepo = "library/" + imagerepo
-        url = self.index_url + '/' + imagerepo + "/manifests/" + tag
+        url = self.index_url + '/v2/' + imagerepo + "/manifests/" + tag
         msg.out("repo url:", url, l=2)
         (hdr, buf) = self._get_url(url)
         try:
@@ -2338,7 +2338,7 @@ class DockerIoAPI(object):
         if "Token" in www_authenticate:
             if imagerepo:
                 auth_url = self.index_url + \
-                    "/repositories/" + imagerepo + "/images"
+                    "/v1/repositories/" + imagerepo + "/images"
                 (auth_hdr, dummy) = self._get_url(
                     auth_url, header=["X-Docker-Token: true"])
                 try:
@@ -2535,9 +2535,9 @@ class DockerIoAPI(object):
     def search_get_page(self, expression, page):
         """Get search result pages from Docker Hub"""
         if expression:
-            url = self.index_url + "/search?q=" + expression
+            url = self.index_url + "/v1/search?q=" + expression
         else:
-            url = self.index_url + "/search?"
+            url = self.index_url + "/v1/search?"
         if page:
             url += "&page=" + str(page)
         (dummy, buf) = self._get_url(url)
@@ -2975,7 +2975,7 @@ class Udocker(object):
             components = imagespec.split("/")
             registry = components [0]
             imagespec = "/".join(components[1:])
-            self.dockerioapi.index_url = "https://%s/v2" % registry
+            self.dockerioapi.index_url = "https://%s" % registry
             self.dockerioapi.registry_url = 'https://%s' % registry
         if cmdp.missing_options():               # syntax error
             return False

--- a/udocker.py
+++ b/udocker.py
@@ -2316,6 +2316,8 @@ class DockerIoAPI(object):
 
     def get_repo_list(self, imagerepo, tag):
         """Get list of images in a repo from Docker Hub"""
+        if not '/' in imagerepo:
+            imagerepo = "library/" + imagerepo
         url = self.index_url + '/' + imagerepo + "/manifests/" + tag
         msg.out("repo url:", url, l=2)
         (hdr, buf) = self._get_url(url)

--- a/udocker.py
+++ b/udocker.py
@@ -680,9 +680,9 @@ class Container(object):
         """Make sure we have a reasonable default PATH and CWD"""
         path = self._getenv("PATH")
         if not path and self.opt["uid"] == "0":
-            path = "/usr/sbin:/sbin:/usr/bin:/bin"
+            path = "/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin"
         elif not path:
-            path = "/usr/bin:/bin"
+            path = "/usr/local/bin:/usr/bin:/bin"
         self.opt["env"].append("PATH=%s" % path)
         # verify if the working directory is valid and fixit
         if not self.opt["cwd"]:

--- a/udocker.py
+++ b/udocker.py
@@ -694,6 +694,10 @@ class Container(object):
         return True
 
     def check_cwd(self, container_root):
+        """
+        Check that cwd exists either in the container_root or
+        in the mountpoint and is a directory.
+        """
         cwd = self.opt["cwd"]
         if os.path.isdir(container_root + "/" + cwd):
             return True
@@ -753,9 +757,9 @@ class Container(object):
             else:
                 host_path, container_path = volume.split(':')
             if exec_name.startswith(container_path):
-               relative_path = exec_name.split(container_path)[1].lstrip('/')
-               if os.path.isfile(os.path.join(host_path, relative_path)):
-                   return os.path.join(host_path, relative_path)
+                relative_path = exec_name.split(container_path)[1].lstrip('/')
+                if os.path.isfile(os.path.join(host_path, relative_path)):
+                    return os.path.join(host_path, relative_path)
 
     def _run_load_metadata(self, container_id):
         """Load container metadata from container JSON payload"""
@@ -2973,7 +2977,7 @@ class Udocker(object):
         registry = ""
         if len(imagespec.split("/")) == 3:
             components = imagespec.split("/")
-            registry = components [0]
+            registry = components[0]
             imagespec = "/".join(components[1:])
             self.dockerioapi.index_url = "https://%s" % registry
             self.dockerioapi.registry_url = 'https://%s' % registry


### PR DESCRIPTION
Hey there,

I have worked on some overall improvements to udocker.
These are:
- allow working_dir and executable to be inside of a mountpoint
- add /usr/loca/bin/ and /usr/local/sbin to the default path
- mimic the `docker images` command more closely
- improve downloading and storing images from non-dockerhub registries like quay.io.
  In docker, if you pull an image using `docker pull quay.io/<namespace>/<image>/<tag>`, it will be listed under that name. With this PR it would behave the same way if you do `udocker.py pull quay.io/<namespace>/<image>/<tag>`.

I hope these changes can be integrated here, since I think this makes it easier to use udocker as an alternative to docker.
