### PR TITLE
Handle entrypoint when not in PATH, but in CWD

### DIFF
--- a/udocker.py
+++ b/udocker.py
@@ -1242,6 +1242,9 @@ class ExecutionEngine(object):
         self.opt["cmd"] = self._quote(self.opt["cmd"])
         if exec_name.startswith("/"):
             exec_path = container_root + exec_name
+        # exe started from work dir
+        elif exec_name.startswith("."):
+            exec_path = container_root + "/" + self.opt["cwd"] + exec_name[1:]
         else:
             exec_path = \
                 FileUtil(exec_name).find_inpath(path, container_root + "/")


### PR DESCRIPTION
Typically happened to me with this image: https://hub.docker.com/r/biomedia/abdominal_stitching/

In this image, the Dockerfile would look like this:

```
WORKDIR /vol/medic02/users/xxx/coding/medical/mira/build/stitching

ENTRYPOINT ["./stitching"]
```

where `stitching` is a binary present in the CWD but CWD is not in PATH.
Docker behaves this way and executes the entrypoint in the CWD.