### PR TITLE
Force usage of python2

### DIFF
--- a/udocker.py
+++ b/udocker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 ========
 udocker


### PR DESCRIPTION
Some distributions are starting to switch to python 3 as the default system.

Since the codebase is not yet compatible with Python 3, we can explicitly request python2 as the runner for the script and it will run on those systems.

I do not know of any distributions or environments where this change could break usage.