### PR TITLE
Fixed creating the correct auth header when no standard hub images is…

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -3558,6 +3558,10 @@ class DockerIoAPITestCase(unittest.TestCase):
         out = doia._get_v2_auth(www_authenticate, False)
         self.assertEqual(out, "Authorization: Bearer YYY")
 
+        www_authenticate = "BASIC realm=Sonatype Nexus Repository"
+        out = doia._get_v2_auth(www_authenticate, False)
+        self.assertEqual(out, "Authorization: Basic %s" %doia.v2_auth_token)
+
 class ChkSUMTestCase(unittest.TestCase):
     """Test ChkSUM() performs checksums portably."""
 

--- a/udocker.py
+++ b/udocker.py
@@ -4940,6 +4940,9 @@ class DockerIoAPI(object):
                     auth_header = "Authorization: Bearer " + \
                         auth_token["token"]
                     self.v2_auth_header = auth_header
+        elif 'BASIC' in bearer:
+            auth_header = "Authorization: Basic %s" %(self.v2_auth_token)
+            self.v2_auth_header = auth_header
         return auth_header
 
     def get_v2_login_token(self, username, password):


### PR DESCRIPTION
This PR fixes issues related to create the auth header when no standard Docker registry is used. 
As an example, unauthenticated requests to _Sonatype Nexus Repository_ returns a _www-authenticate_ header as *BASIC realm="Sonatype Nexus Repository* which implied an empty auth header returned by the *_get_v2_auth* function.