### PR TITLE
Update udocker.py

### DIFF
--- a/udocker.py
+++ b/udocker.py
@@ -5376,7 +5376,7 @@ class DockerLocalFileAPI(object):
     def _untar_saved_container(self, tarfile, destdir):
         """Untar container created with docker save"""
         cmd = "umask 022 ; tar -C " + \
-            destdir + " -x --delay-directory-restore "
+            destdir + " -x "
         if Msg.level >= Msg.VER:
             cmd += " -v "
         cmd += " --one-file-system --no-same-owner "


### PR DESCRIPTION
At some systems '--delay-directory-restore' is not available. In that case, import of the exported image ends up with:

Error: failed to extract container: image.tar
Error: loading failed 

After looking into udocker.py it turned out that issue is here:

tar: unrecognized option `--delay-directory-restore'
Try `tar --help' or `tar --usage' for more information.