### PR TITLE
Update soon to be decommissioned URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,6 @@ When citing udocker please use the following:
 * PRoot https://proot-me.github.io/
 * Fakechroot https://github.com/dex4er/fakechroot/wiki
 * runC https://runc.io/
-* Singularity http://singularity.lbl.gov
+* Singularity https://www.sylabs.io/
 * INDIGO DataCloud https://www.indigo-datacloud.eu
 


### PR DESCRIPTION
This [URL](https://www.sylabs.io/guides/2.5.1/user-guide/introduction.html#welcome-to-singularity) might be also suitable, since their top-level page isn't very informative. But their documentation is pinned to a specific version, which I guess makes it a rather bad target linking to.