### PR TITLE
Add registry detection on image name, fix basic auth when realm is Basic

### DIFF
--- a/udocker.py
+++ b/udocker.py
@@ -5279,7 +5279,7 @@ class DockerIoAPI(object):
                         auth_token["token"]
                     self.v2_auth_header = auth_header
         # PR #126
-        elif 'BASIC' in bearer:
+        elif 'BASIC' in bearer or 'Basic' in bearer:
             auth_header = "Authorization: Basic %s" %(self.v2_auth_token)
             self.v2_auth_header = auth_header
         return auth_header
@@ -6201,6 +6201,8 @@ class Udocker(object):
         registry_url = cmdp.get("--registry=")
         http_proxy = cmdp.get("--httpproxy=")
         (imagerepo, tag) = self._check_imagespec(cmdp.get("P1"))
+        if self.keystore.get(imagerepo.split("/")[0]):
+            registry_url = imagerepo.split("/")[0]
         if (not imagerepo) or cmdp.missing_options():    # syntax error
             return False
         else:


### PR DESCRIPTION
Hi,

A small improvement in this PR : 

Like docker, if we're logged in, the pull command will now use the configured registry authentication.

One issue to note though : 

This currently assumes that the registry is stored with 
```registry.dns.name``` instead of ```https://registry.dns.name```.

Since using any of them works, can I suggest we default the documentation and help messages to ```registry.dns.name``` ?
