### PR TITLE
Store docker content digest and add limited gcr support

### DIFF
--- a/udocker.py
+++ b/udocker.py
@@ -4128,7 +4128,7 @@ class LocalRepository(object):
         """See if container or image tag are protected"""
         tag_hash=""
         if os.path.exists(directory + "/hash"):
-                tag_hash=self.load_json(directory + "/hash")
+            tag_hash=self.load_json(directory + "/hash")
         return tag_hash
 
     def iswriteable_container(self, container_id):
@@ -5165,7 +5165,7 @@ class DockerIoAPI(object):
                     auth_kwargs = kwargs.copy()
                     headers=[auth_header]
                     if 'accept' in kwargs:
-                       headers=[auth_header,kwargs['accept']]
+                        headers=[auth_header,kwargs['accept']]
                     auth_kwargs.update({"header": headers})
                     if "location" in hdr.data and hdr.data['location']:
                         args = hdr.data['location']


### PR DESCRIPTION
Added gcr support:

Before:
$ ./udocker pull us.gcr.io/broad-gotc-prod/verify-bam-id:c8a66425c312e5f8be46ab0c41f8d7a1942b6e16-1500298351
Error: no files downloaded
After:
$ ./udocker pull us.gcr.io/broad-gotc-prod/verify-bam-id:c8a66425c312e5f8be46ab0c41f8d7a1942b6e16-1500298351
Downloading layer: sha256:9f0706ba7422412cd468804fee456786f88bed94bf9aea6dde2a47f770d19d27
Downloading layer: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
Downloading layer: sha256:d3942a742d221ef22a0a335c4eebf09e15a36dcfb224b5a2d0cdcc405f374ccb
...

Added docker content digest support:

Before:
$ ./udocker.py images
REPOSITORY
us.gcr.io/broad-gotc-prod/verify-bam-id:c8a66425c312e5f8be46 .
ubuntu:16.04

After:
$ ./udocker images
REPOSITORY
us.gcr.io/broad-gotc-prod/verify-bam-id:c8a66425c312e5f8be46ab0c41f8d7a1942b6e16-1500298351 . sha256:dd99e387057578e4d42bd0677a79b25383011817d68365b5c2d222c0a1eeee78
ubuntu:16.04                                                 . sha256:58d0da8bc2f434983c6ca4713b08be00ff5586eb5cdff47bcde4b2e88fd40f88