### PR TITLE
Add option to disable banner

### DIFF
--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -555,6 +555,7 @@ Options:
 * `--bindhome` attempt to make the user home directory appear inside the container
 * `--kernel=KERNELID` use a specific kernel id to emulate useful when the host kernel is too old
 * `--location=DIR` execute a container in a given directory
+* `--nobanner` disable printing of the banner displaying the container ID
 
 Options valid only in Pn execution modes:
 

--- a/udocker.py
+++ b/udocker.py
@@ -2477,6 +2477,7 @@ class ExecutionEngineCommon(object):
         self.opt["portsmap"] = []                # Ports mapped in container
         self.opt["portsexp"] = []                # Ports exposed by container
         self.opt["devices"] = []                 # Devices passed to container
+        self.opt["nobanner"] = False             # Don't show banner
 
     def _has_option(self, search_option, arg=None):
         """Check if executable has a given cli option"""
@@ -3023,14 +3024,15 @@ class ExecutionEngineCommon(object):
 
     def _run_banner(self, cmd, char='*'):
         """Print a container startup banner"""
-        Msg().err("",
-                  '\n', char * 78,
-                  '\n', char, ' ' * 74, char,
-                  '\n', char,
-                  ("STARTING " + self.container_id).center(74, ' '), char,
-                  '\n', char, ' ' * 74, char,
-                  '\n', char * 78, '\n',
-                  "executing:", os.path.basename(cmd), l=Msg.INF)
+        if not self.opt["nobanner"]:
+            Msg().err("",
+                      '\n', char * 78,
+                      '\n', char, ' ' * 74, char,
+                      '\n', char,
+                      ("STARTING " + self.container_id).center(74, ' '), char,
+                      '\n', char, ' ' * 74, char,
+                      '\n', char * 78, '\n',
+                      "executing:", os.path.basename(cmd), l=Msg.INF)
 
     def _run_env_cleanup_dict(self):
         """Allow only to pass essential environment variables."""
@@ -7699,6 +7701,10 @@ class Udocker(object):
             "devices": {
                 "fl": ("--device=",), "act": 'E',
                 "p2": "CMD_OPT", "p3": True
+            },
+            "nobanner": {
+                "fl": ("--nobanner",), "act": 'R',
+                "p2": "CMD_OPT", "p3": False
             }
         }
         for option, cmdp_args in cmd_options.iteritems():
@@ -7739,6 +7745,7 @@ class Udocker(object):
         --bindhome                 :bind the home directory into the container
         --kernel=<kernel-id>       :use this Linux kernel identifier
         --location=<path-to-dir>   :use root tree outside the repository
+        --nobanner                 :don't print a startup banner
 
         Only available in Rn execution modes:
         --device=/dev/xxx          :pass device to container (R1 mode only)


### PR DESCRIPTION
In some instances (e.g. in scripts) printing a banner on each `udocker run` is not desirable. This PR adds an option to disable said banner with `--nobanner`.