### PR TITLE
Base64 conversion requires bytes, not a string

### DIFF
--- a/udocker/docker.py
+++ b/udocker/docker.py
@@ -310,7 +310,7 @@ class DockerIoAPI(object):
             return ""
         try:
             self.v2_auth_token = \
-                base64.b64encode("%s:%s" % (username, password))
+                base64.b64encode(("%s:%s" % (username, password)).encode("utf-8")).decode("ascii")
         except (KeyError, AttributeError, TypeError, ValueError, NameError):
             self.v2_auth_token = ""
         return self.v2_auth_token


### PR DESCRIPTION
Base64 [requires a bytes-like object](https://docs.python.org/3/library/base64.html), not a string.

In **do_login**, convert username:password to byte for **base64.b64encode**, then back to ASCII for **json.dump**