### PR TITLE
Login supposes that keystore.put returns 0 when success

### DIFF
--- a/udocker/cli.py
+++ b/udocker/cli.py
@@ -470,7 +470,7 @@ class UdockerCLI(object):
                       "Caps Lock ?", l=Msg.WAR)
 
         v2_auth_token = self.dockerioapi.get_v2_login_token(username, password)
-        if self.keystore.put(self.dockerioapi.registry_url, v2_auth_token, ""):
+        if self.keystore.put(self.dockerioapi.registry_url, v2_auth_token, "") == 0:
             return self.STATUS_OK
 
         Msg().err("Error: invalid credentials")


### PR DESCRIPTION
Compared with release 1.1.7, the [devel3](https://github.com/indigo-dc/udocker/tree/devel3) branch seems to have inverted the way that results of keystore **put** and **delete** operations are reported, to return 0 for success rather than a Boolean value. Consequently, **do_login** misinterprets a successful write as a failure, and the CLI reports invalid credentials.

This isn't a problem for **do_logout**, which returns the exit status to the shell, where it is correctly interpreted.