### PR TITLE
Fix concurrent jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,12 @@
 def projectConfig
 
 pipeline {
-    agent any
+    agent { label 'udocker' }
+
+    options {
+        lock('udocker')
+        throttle(['StandaloneByNode'])
+    }
 
     stages {
         stage('SQA baseline dynamic stages') {


### PR DESCRIPTION
When more than one job runs in parallel, docker-compose up fails because container already exists.
With this PR this issue is solved using locks to only allow a single job to run.