### PR TITLE
Specify an arm64v8 Docker image for Android

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1364,7 +1364,7 @@ provided by Termux which is adapted to the Termux Android environment.
 
 ```bash
 export UDOCKER_USE_PROOT_EXECUTABLE=$(which proot)
-udocker run ubuntu:18.04
+udocker run arm64v8/fedora:35
 ```
 
 ### 11.2. Google Colab


### PR DESCRIPTION
The steps outlined, don't work out of the box on most Android devices
as an x86 docker image is being attempted to be launched on an aarch64
device. The most common type of CPU on Android is aarch64.