### PR TITLE
Fixing command line elements to be able to use digest style image tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,5 @@ setup(
     test_suite='tests',
     tests_require=TEST_REQUIREMENTS,
     url='https://github.com/indigo-dc/udocker',
-    use_2to3=True,
     zip_safe=False,
 )

--- a/udocker/docker.py
+++ b/udocker/docker.py
@@ -47,7 +47,7 @@ class DockerIoAPI(object):
 
     def is_repo_name(self, imagerepo):
         """Check if name matches authorized characters for a docker repo"""
-        if imagerepo and re.match("^[a-zA-Z0-9][a-zA-Z0-9-_./:]+$", imagerepo):
+        if imagerepo and re.match("^[a-zA-Z0-9][a-zA-Z0-9-_./:@]+$", imagerepo):
             return True
         return False
 


### PR DESCRIPTION
Updating behavior for dealing with tags that use the digest format (https://docs.docker.com/engine/reference/commandline/images/#list-image-digests)

Example:
```
udocker pull ubuntu@sha256:7c9c7fed23def3653a0da5bc9ecb651efe155ebd5802c7ba5d585edaa6c89496
```
Previously, this would have failed because the code would not accept the `@` character. Split behavior/join also changes, using the `@` rather then the `:`.

Previously this would have failed. For some tools, such as Cromwell using the digest form is considered to be [best practice](https://cromwell.readthedocs.io/en/stable/tutorials/Containers/#image-versions)