### PR TITLE
casting file_size

### DIFF
--- a/udocker/cli.py
+++ b/udocker/cli.py
@@ -890,7 +890,7 @@ class UdockerCLI:
                 layers_list = self.localrepo.get_layers(imagerepo, tag)
                 if layers_list:
                     for (layer_name, size) in layers_list:
-                        file_size = size / (1024 * 1024)
+                        file_size = int(size / (1024 * 1024))
                         if not file_size and size:
                             file_size = 1
 


### PR DESCRIPTION
improve msg info, if the value is bellow 1024 * 1024 the result of the operation needs casting to int so file_size can be zero 